### PR TITLE
Following specs for deliver_sm_resp

### DIFF
--- a/src/smpp_pdu_syntax.erl
+++ b/src/smpp_pdu_syntax.erl
@@ -78,6 +78,8 @@ pack({CmdId, 0, SeqNum, Body}, PduType) ->
     end;
 pack({CmdId, {command_status, Status}, SeqNum, _Body}, _PduType) ->
     pack({CmdId, Status, SeqNum, _Body}, _PduType);
+pack({CmdId, Status, SeqNum, _Body}, _PduType) when CmdId == ?COMMAND_ID_DELIVER_SM_RESP ->
+    {ok, [<<17:32, CmdId:32, Status:32, SeqNum:32, 0:8>>]};
 pack({CmdId, Status, SeqNum, _Body}, _PduType) ->
     {ok, [<<16:32, CmdId:32, Status:32, SeqNum:32>>]}.
 


### PR DESCRIPTION
I forgot to change length value for deliver_sm_resp pdu last time.
`<<16:32, CmdId:32, Status:32, SeqNum:32, 0:8>>` is wrong.
should be:
`<<17:32, CmdId:32, Status:32, SeqNum:32, 0:8>>`